### PR TITLE
fix error message

### DIFF
--- a/muckrock/__init__.py
+++ b/muckrock/__init__.py
@@ -228,7 +228,7 @@ class FoiaEndpoint(BaseMuckRockClient, BaseEndpointMixin):
         if agency_id:
             assert isinstance(agency_id, int) or (
                 isinstance(agency_id, str) and agency_id.isdigit()
-            ), "agency_id must be a string"
+            ), "agency_id must be a integer"
             params["agency"] = agency_id
         datetime_submitted_choices = {
             None: 1,


### PR DESCRIPTION
I wrote a check that agency_id had to be a integer or a string that could be cast to an integer, and then wrote an error message with the opposite guidance. 

This fixes that.